### PR TITLE
Updated k8s dashboard URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Experiment with using docker compose to deploy multi-container applications
 * [Deploy Containers to Azure aks with Kubernetes](modules/kubernetes/kubernetes.md)
 
 
-## Module : Advanced DevOps (CI/CD), Microservices and Containers Hands-on Lab.
+## Module : Advanced DevOps (CI/CD), Microservices and Containers Hands-on Lab
 * [Build and Deploy a containerized Java Springboot Microservice on AKS](https://github.com/ganrad/k8s-springboot-data-rest.git)
 
 

--- a/README.md
+++ b/README.md
@@ -44,14 +44,18 @@ Experiment with using docker compose to deploy multi-container applications
 * [Deploy multicontainer applications](modules/swarm/part2/multiapp.md)
 
 
+## Module : Deploy an Azure Container Instance
+
+* [Deploying container to an Azure Container Instance](modules/azurecontainerinstances/aci.md)
+
+
 ## Module : Deploy Containers to Azure aks with Kubernetes
 
 * [Deploy Containers to Azure aks with Kubernetes](modules/kubernetes/kubernetes.md)
 
 
-## Module : Deploy an Azure Container Instance
-
-* [Deploing container to an Azure Container Instance](modules/azurecontainerinstances/aci.md)
+## Module : Advanced DevOps (CI/CD), Microservices and Containers Hands-on Lab.
+* [Build and Deploy a containerized Java Springboot Microservice on AKS](https://github.com/ganrad/k8s-springboot-data-rest.git)
 
 
 ## Module : Securing Containerized Applications

--- a/modules/kubernetes/kubernetes.md
+++ b/modules/kubernetes/kubernetes.md
@@ -163,7 +163,6 @@ The Kubernetes Dashboard is web interface that provides general-purpose monitori
     ```none
     kubectl proxy -p 8001
     ```
-2. Open the browser on you machine and navigate to [http://localhost:8001/ui](http://localhost:8001/ui)
 2. Open the browser on you machine and navigate to [http://localhost:8001/api/v1/namespaces/kube-system/services/http:kubernetes-dashboard:/proxy/](http://localhost:8001/api/v1/namespaces/kube-system/services/http:kubernetes-dashboard:/proxy/)
 
 3. You can also try:

--- a/modules/kubernetes/kubernetes.md
+++ b/modules/kubernetes/kubernetes.md
@@ -164,6 +164,7 @@ The Kubernetes Dashboard is web interface that provides general-purpose monitori
     kubectl proxy -p 8001
     ```
 2. Open the browser on you machine and navigate to [http://localhost:8001/ui](http://localhost:8001/ui)
+2. Open the browser on you machine and navigate to [http://localhost:8001/api/v1/namespaces/kube-system/services/http:kubernetes-dashboard:/proxy/](http://localhost:8001/api/v1/namespaces/kube-system/services/http:kubernetes-dashboard:/proxy/)
 
 3. You can also try:
     ```


### PR DESCRIPTION
K8S Dashboard UI has changed.  http://localhost:port/ui has been deprecated (issue link is pasted below).  In fact, this old URL will not be available in k8s v1.10.
Issue => https://github.com/kubernetes/dashboard/issues/2669
Link to k8s dashboard => https://github.com/kubernetes/dashboard/